### PR TITLE
fix(solo-makeover): update LokiNGINX datsource

### DIFF
--- a/solo_makeover.md
+++ b/solo_makeover.md
@@ -12,7 +12,7 @@ Follow these steps to Import it:
 4. You will be asked to choose three of your dashboard's data sources:
     - For TestData DB, choose `TestData DB`.
     - For Prometheus (Cloud), choose `Prometheus (Cloud)`.
-    - For LokiNGINX, choose `Loki (Cloud)`.
+    - For LokiNGINX, choose `LokiNginxLogs`.
     - Click on *Import*.
 
 *While our existing dashboard already has useful information such as RED metrics - request rates, errors, and duration/latency - for our service as well as state information for the underlying Kubernetes pods and end-user activity from a geographic lens, our aim is to make the information on the dashboard easier to understand and more visually appealing.*


### PR DESCRIPTION
Change Loki datasource from "Loki (Cloud)" to "LokiNginxLogs", the former doesn't has data necessary for the "Customer Activity" widget in the Dull Dashboard